### PR TITLE
fix: revert header to older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,11 +29,6 @@
             </svg>
         </button>
 
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
-
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">


### PR DESCRIPTION
Removes the Course Materials Assistant header, subheader, and horizontal row while keeping the theme toggle functionality.

Fixes #2

---

Generated with [Claude Code](https://claude.ai/code)